### PR TITLE
Fix UI Updates

### DIFF
--- a/Core/Store.swift
+++ b/Core/Store.swift
@@ -148,10 +148,11 @@ public class Store<Product: Purchaseable> {
                                                                 self.dismissAvailablePurchasesModal(wasCancelled: true)
         })
         
-        presentingViewController.present(modalViewController, animated: true, completion: nil)
         self.modalViewController = modalViewController
-        refreshProductsList()
         
+        presentingViewController.present(modalViewController, animated: true) { [weak self] in
+            self?.refreshProductsList()
+        }
     }
     
     

--- a/iOS/Source/IAPDialogViewController.swift
+++ b/iOS/Source/IAPDialogViewController.swift
@@ -71,9 +71,11 @@ class IAPDialogViewController: IAPViewController {
     
     var products = [StoreProduct]() {
         didSet {
-            collectionView.reloadData()
-            UIView.animate(withDuration: 0.2) {
-                self.activityView.alpha = 0.0
+            DispatchQueue.main.async { [weak self] in
+                self?.collectionView.reloadData()
+                UIView.animate(withDuration: 0.2) {
+                    self?.activityView.alpha = 0.0
+                }
             }
         }
     }


### PR DESCRIPTION
## Objective

This PR fixes 2 distinct problems. The problems are related in that they both potentially prevent the user from seeing the list of products.

1. A crash caused by a race condition
2. The list of products not loading because there is potential for UI API to be called on a background thread.

## Description

#### Problem 1
*TLDR;* The crash was caused by trying to access an IBOutlet that was `nil`.

After making the call to present the `IAPDialogViewController` we make the call to refresh the product list.

When we successfully refresh the product list in `Store.swift` `refreshProductsList()`, we update the `products` property of the `modalViewController`. 

> `modalViewController.products = storeProducts`

When the `products` property is set on the `IAPDialogViewController` we try to reload data in the collection view.

> `collectionView.reloadData()`

This can cause a crash if the asynchronous task to refresh the product list completes before the `modalViewController` is presented. In this case, the outlets on the view controller have not been initialized and the app will crash because it tries to access a non-optional property that has not been initialized.

To fix this I moved the call to refresh the product list to the completion handler of the presentation method. This ensures that the `modalViewController` will be presented and all its outlets initialized before the `refreshProductsList()` method is called.

#### Problem 2
Loading the products can appear to take a long time because it is possible to update the UI from a background thread - like in the example above. We refresh the product list and in a completion handler we set the new products, which in turn has a property setter that tries to update the UI.

The fix for this was to simply dispatch those UI updates to the main thread.

## Merge Checklist

- [ ] iOS Example app target builds and runs
- [ ] iOS Example tested on iPad 1/3 Split Screen
- [ ] iOS Example tested on iPad 1/2 Split Screen
- [ ] iOS Example tested on iPad 2/3 Split Screen
- [ ] iOS Example tested on iPhone 5
- [ ] iOS Example tested on iPhone 8+
- [ ] iOS Example tested on iPhone X
